### PR TITLE
feat: remove company limit after outages get resolved

### DIFF
--- a/examples/yc-batch-company-employees/src/app/api/process-batch/process-batch.controller.ts
+++ b/examples/yc-batch-company-employees/src/app/api/process-batch/process-batch.controller.ts
@@ -20,7 +20,7 @@ export async function processBatchController({
     const companies = await yCombinator.getCompaniesInBatch(batch, sessionId);
 
     // Get LinkedIn profile urls for the companies
-    const linkedInProfileUrls = await yCombinator.getCompaniesLinkedInProfileUrls(companies.slice(0, 3));
+    const linkedInProfileUrls = await yCombinator.getCompaniesLinkedInProfileUrls(companies);
 
     const isLoggedIn = await linkedin.checkIfSignedIntoLinkedIn(sessionId);
 


### PR DESCRIPTION
Removes the slice of companies fetched from YC.
This was introduced to avoid the timeouts and outages that were discovered in the last couple of days