### PR TITLE
fix: fix fetch calls

### DIFF
--- a/examples/linkedin-data-extraction/src/components/forms/ContinueForm.tsx
+++ b/examples/linkedin-data-extraction/src/components/forms/ContinueForm.tsx
@@ -34,7 +34,7 @@ export function ContinueForm() {
     setIsSubmitting(true);
 
     try {
-      const response = await fetch("/api/continue", {
+      const response = await fetch("api/continue", {
         method: "POST",
         body: JSON.stringify({
           apiKey,

--- a/examples/linkedin-data-extraction/src/components/forms/StartForm.tsx
+++ b/examples/linkedin-data-extraction/src/components/forms/StartForm.tsx
@@ -45,7 +45,7 @@ export function StartForm() {
   const onSubmit = useCallback(
     async (data: StartRequest) => {
       try {
-        const response = await fetch("/api/start", {
+        const response = await fetch("api/start", {
           method: "POST",
           body: JSON.stringify(data),
         });

--- a/examples/yc-batch-company-employees/src/components/forms/BatchSelectionForm.tsx
+++ b/examples/yc-batch-company-employees/src/components/forms/BatchSelectionForm.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
   useHandleError,
 } from "@local/ui";
+import { getLogger } from "@local/utils";
 import { useCallback, useState } from "react";
 
 interface BatchSelectorFormProps {
@@ -32,15 +33,17 @@ export function BatchSelectorForm({ batches }: BatchSelectorFormProps) {
   const handleError = useHandleError();
 
   const handleBatchSelect = useCallback(async () => {
+    const log = getLogger().withPrefix("[BatchSelectionForm]");
+
     if (!selectedBatch || !sessionId) {
-      console.error("Missing required data:", { selectedBatch, sessionId });
+      log.withMetadata({ selectedBatch, sessionId }).error("Missing required data");
       return;
     }
 
     setIsSubmitting(true);
     try {
-      console.log("Sending request to /api/process-batch");
-      const response = await fetch("/api/process-batch", {
+      log.info("Sending request to api/process-batch");
+      const response = await fetch("api/process-batch", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -59,7 +62,7 @@ export function BatchSelectorForm({ batches }: BatchSelectorFormProps) {
       }
 
       const result = await response.json();
-      console.log("Success response:", result);
+      log.info("Success response:", result);
       setProcessBatchResponse(result);
     } catch (e: any) {
       handleError({

--- a/examples/yc-batch-company-employees/src/components/forms/ContinueForm.tsx
+++ b/examples/yc-batch-company-employees/src/components/forms/ContinueForm.tsx
@@ -34,7 +34,7 @@ export function ContinueForm() {
     setIsSubmitting(true);
 
     try {
-      const response = await fetch("/api/continue", {
+      const response = await fetch("api/continue", {
         method: "POST",
         body: JSON.stringify({
           apiKey,

--- a/examples/yc-batch-company-employees/src/components/forms/StartForm.tsx
+++ b/examples/yc-batch-company-employees/src/components/forms/StartForm.tsx
@@ -45,7 +45,7 @@ export function StartForm() {
   const onSubmit = useCallback(
     async (data: StartRequest) => {
       try {
-        const response = await fetch("/api/start", {
+        const response = await fetch("api/start", {
           method: "POST",
           body: JSON.stringify(data),
         });


### PR DESCRIPTION
When the example runs under a proxied directory, the fetch call will fail with a 405 because it's referencing /api and not `<directory>/api`.