### PR TITLE
[Fix] Timeout in continue endpoint

### DIFF
--- a/examples/yc-batch-company-employees/src/app/api/continue/route.ts
+++ b/examples/yc-batch-company-employees/src/app/api/continue/route.ts
@@ -7,6 +7,8 @@ import {
 import { getLogger } from "@local/utils";
 import { type NextRequest, NextResponse } from "next/server";
 
+export const maxDuration = 300;
+
 /**
  * Continues the process of extracting data from yCombinator after the user has completed sign-in.
  */


### PR DESCRIPTION
### About

Vercel limits the execution of API routes to 10 sec by default. To increase the time limit we have to export a constant in each `route.ts` that requires more time to finish.
