### PR TITLE
fix: [AIR-1318] change log level to error only on prod

### DIFF
--- a/packages/utils/src/logging.ts
+++ b/packages/utils/src/logging.ts
@@ -1,10 +1,25 @@
-import { LogLayer, LoggerType } from "loglayer";
+import { LogLayer, LoggerType, type PluginShouldSendToLoggerParams } from "loglayer";
 
 const logger = new LogLayer({
   logger: {
     instance: console,
     type: LoggerType.CONSOLE,
   },
+  plugins: [
+    {
+      shouldSendToLogger(params: PluginShouldSendToLoggerParams) {
+        // This would be empty on the client side; client-side logging is fine
+        if (!process.env.NODE_ENV) {
+          return true;
+        }
+
+        // server-side
+        // Do not log anything in production if the log level is not error
+        // This is to avoid logging sensitive information in production
+        return !(process.env.NODE_ENV === "production" && params.logLevel !== "error");
+      },
+    },
+  ],
 });
 
 export function getLogger(): LogLayer {


### PR DESCRIPTION
This only allows error logging through on the server side.

Testing:

visit any one of the previews for a deployed site. check that logs don't get printed unless its an error