### PR TITLE
YC Batch Recipe Fix

### DIFF
--- a/examples/yc-batch-company-employees/package.json
+++ b/examples/yc-batch-company-employees/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internal/home-config": "workspace:*",
-    "@airtop/sdk": "0.1.14",
+    "@airtop/sdk": "0.1.31",
     "@hookform/resolvers": "3.9.1",
     "@inquirer/prompts": "7.1.0",
     "@local/ui": "workspace:*",

--- a/examples/yc-batch-company-employees/src/app/api/process-batch/process-batch.controller.ts
+++ b/examples/yc-batch-company-employees/src/app/api/process-batch/process-batch.controller.ts
@@ -25,15 +25,9 @@ export async function processBatchController({
     // At this point we should be logged in, so we terminate the session to persist profile
     await airtop.terminateSession(sessionId);
 
-    // Get employee list url for each company
-    const employeesListUrls = await linkedin.getEmployeesListUrls({
-      companyLinkedInProfileUrls: linkedInProfileUrls,
-      profileName,
-    });
-
-    // Get employee's Profile Urls for each employee list url
+    // Get employee's Profile Urls for each company
     const employeesProfileUrls = await linkedin.getEmployeesProfileUrls({
-      employeesListUrls: employeesListUrls,
+      companyLinkedInProfileUrls: linkedInProfileUrls,
       profileName,
     });
 

--- a/examples/yc-batch-company-employees/src/cli/yc-company-employees.cli.ts
+++ b/examples/yc-batch-company-employees/src/cli/yc-company-employees.cli.ts
@@ -72,13 +72,8 @@ async function cli() {
       await airtop.terminateSession(ycSession.data.id);
     }
 
-    const employeesListUrls = await linkedInService.getEmployeesListUrls({
-      companyLinkedInProfileUrls: linkedInProfileUrls,
-      profileName,
-    });
-
     await linkedInService.getEmployeesProfileUrls({
-      employeesListUrls: employeesListUrls,
+      companyLinkedInProfileUrls: linkedInProfileUrls,
       profileName,
     });
 

--- a/examples/yc-batch-company-employees/src/consts.ts
+++ b/examples/yc-batch-company-employees/src/consts.ts
@@ -103,3 +103,19 @@ const GET_COMPANY_LINKEDIN_PROFILE_URL_SCHEMA = baseSchema.extend({
 
 export const GET_COMPANY_LINKEDIN_PROFILE_URL_OUTPUT_SCHEMA = zodToJsonSchema(GET_COMPANY_LINKEDIN_PROFILE_URL_SCHEMA);
 export type GetCompanyLinkedInProfileUrlResponse = z.infer<typeof GET_COMPANY_LINKEDIN_PROFILE_URL_SCHEMA>;
+
+export const GET_EMPLOYEES_PROFILES_PROMPT = `
+You are looking at a LinkedIn's people tab of a company.
+Extract the linkedIn profile urls of the employees you see of the company.
+
+The profile urls typically (but not limited to) have the format of linkedin.com/in/<identifier of the employee>. These are the kind of links you should extract and return.
+
+Do not return profile urls of people that are not from the company.
+`;
+
+export const GET_EMPLOYEES_PROFILES_SCHEMA = baseSchema.extend({
+  employees_profile_urls: z.array(z.string()),
+});
+
+export const GET_EMPLOYEES_PROFILES_OUTPUT_SCHEMA = zodToJsonSchema(GET_EMPLOYEES_PROFILES_SCHEMA);
+export type GetEmployeesProfilesResponse = z.infer<typeof GET_EMPLOYEES_PROFILES_SCHEMA>;

--- a/examples/yc-batch-company-employees/src/consts.ts
+++ b/examples/yc-batch-company-employees/src/consts.ts
@@ -88,26 +88,17 @@ export type GetCompaniesInBatchResponse = z.infer<typeof GET_COMPANIES_IN_BATCH_
 
 export const GET_COMPANY_LINKEDIN_PROFILE_URL_PROMPT = `
 You are looking at a specific company's profile page on Y Combinator.
+
 Your task is to extract the company's official LinkedIn URL.
+The LinkedIn URL is typically found alongside information like year founded, team size, status, etc.
 
-Guidelines:
-1. The LinkedIn URL should be from the company information section alongside the company's name, founded year, team size, location, and other information.
-2. Valid formats include (but are not limited to):
-   - https://www.linkedin.com/company/[company-name]
-   - https://linkedin.com/company/[company-name]
-3. Do NOT extract:
-   - Personal LinkedIn profiles of founders/employees
-   - LinkedIn URLs from other sections of the page
-   - Malformed or partial LinkedIn URLs
-
-Return null if:
-- No LinkedIn URL is present
-- Only founder/employee LinkedIn profiles are found
-- The URL format is invalid or suspicious
+Important:
+- Be careful not to confuse the company's LinkedIn URL with the LinkedIn profile of a specific employee, or CEO/CTO.
+- The company LinkedIn URL can sometimes have the following format: https://www.linkedin.com/company/company-name/<company-name>. It is not limited to that format.
 `;
 
 const GET_COMPANY_LINKEDIN_PROFILE_URL_SCHEMA = baseSchema.extend({
-  linkedInProfileUrl: z.string().nullable().describe("The LinkedIn profile URL or null if not found"),
+  linkedInProfileUrl: z.string().describe("The LinkedIn profile URL or null if not found"),
 });
 
 export const GET_COMPANY_LINKEDIN_PROFILE_URL_OUTPUT_SCHEMA = zodToJsonSchema(GET_COMPANY_LINKEDIN_PROFILE_URL_SCHEMA);

--- a/examples/yc-batch-company-employees/src/consts.ts
+++ b/examples/yc-batch-company-employees/src/consts.ts
@@ -110,7 +110,7 @@ Extract the linkedIn profile urls of the employees you see of the company.
 
 The profile urls typically (but not limited to) have the format of linkedin.com/in/<identifier of the employee>. These are the kind of links you should extract and return.
 
-Do not return profile urls of people that are not from the company.
+Do not return profile urls of people that are not from the company. Only return profile urls of employees found in the 'People you may know' section.
 `;
 
 export const GET_EMPLOYEES_PROFILES_SCHEMA = baseSchema.extend({

--- a/examples/yc-batch-company-employees/src/lib/services/yc-extractor.service.ts
+++ b/examples/yc-batch-company-employees/src/lib/services/yc-extractor.service.ts
@@ -48,6 +48,9 @@ export class YCExtractorService {
       url: YC_COMPANIES_URL,
     });
 
+    // Set a small wait time to ensure the page is loaded
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
     this.log.info("Extracting YC batches");
     // Extract the batches from the YC Company Directory page
     const modelResponse = await this.airtop.client.windows.pageQuery(session.data.id, window.data.windowId, {
@@ -91,6 +94,9 @@ export class YCExtractorService {
     const window = await this.airtop.client.windows.create(session.data.id, {
       url: `${YC_COMPANIES_URL}?batch=${batch}`,
     });
+
+    // Set a small wait time to ensure the page is loaded
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     this.log.info(`Extracting companies in batch "${batch}"`);
     const modelResponse = await this.airtop.client.windows.pageQuery(session.data.id, window.data.windowId, {

--- a/examples/yc-batch-company-employees/src/lib/services/yc-extractor.service.ts
+++ b/examples/yc-batch-company-employees/src/lib/services/yc-extractor.service.ts
@@ -138,7 +138,7 @@ export class YCExtractorService {
       const modelResponse = await this.airtop.client.windows.pageQuery(input.sessionId, input.windowId, {
         prompt: GET_COMPANY_LINKEDIN_PROFILE_URL_PROMPT,
         configuration: {
-          outputSchema: GET_COMPANY_LINKEDIN_PROFILE_URL_OUTPUT_SCHEMA,
+          outputSchema: JSON.stringify(GET_COMPANY_LINKEDIN_PROFILE_URL_OUTPUT_SCHEMA),
         },
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,8 +604,8 @@ importers:
   examples/yc-batch-company-employees:
     dependencies:
       '@airtop/sdk':
-        specifier: 0.1.14
-        version: 0.1.14(playwright@1.48.2)(puppeteer@23.7.1(typescript@5.7.2))(selenium-webdriver@4.26.0)
+        specifier: 0.1.31
+        version: 0.1.31(playwright@1.48.2)(puppeteer@23.7.1(typescript@5.7.2))(selenium-webdriver@4.26.0)
       '@hookform/resolvers':
         specifier: 3.9.1
         version: 3.9.1(react-hook-form@7.53.2(react@19.0.0-rc-66855b96-20241106))
@@ -930,6 +930,13 @@ packages:
 
   '@airtop/sdk@0.1.16':
     resolution: {integrity: sha512-I9cmcCnU7mYCJFySLeNGPSPx3YuhUUr9W/+zXr60jpZ/33eowbKyij0Sr+9hkXihX5K8t93WM4Y+GjiA8dLh5w==}
+    peerDependencies:
+      playwright: '>=1.47.2'
+      puppeteer: '>=22.14.0'
+      selenium-webdriver: '>=4.25.0'
+
+  '@airtop/sdk@0.1.31':
+    resolution: {integrity: sha512-TXDbtcLHW+KfENFlrsewTpbjpdFZHBIdCsUE7rtjrW2gr7y9Lu7EhczfxJRxMcr0OriPzZfuq+8IsigShPrFMQ==}
     peerDependencies:
       playwright: '>=1.47.2'
       puppeteer: '>=22.14.0'
@@ -4214,6 +4221,22 @@ snapshots:
       - encoding
 
   '@airtop/sdk@0.1.16(playwright@1.48.2)(puppeteer@23.7.1(typescript@5.7.2))(selenium-webdriver@4.26.0)':
+    dependencies:
+      async-mutex: 0.5.0
+      eventemitter3: 5.0.1
+      form-data: 4.0.1
+      formdata-node: 6.0.3
+      js-base64: 3.7.2
+      node-fetch: 2.7.0
+      playwright: 1.48.2
+      puppeteer: 23.7.1(typescript@5.7.2)
+      qs: 6.11.2
+      selenium-webdriver: 4.26.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@airtop/sdk@0.1.31(playwright@1.48.2)(puppeteer@23.7.1(typescript@5.7.2))(selenium-webdriver@4.26.0)':
     dependencies:
       async-mutex: 0.5.0
       eventemitter3: 5.0.1


### PR DESCRIPTION
This PR addresses some of the issues that the YC Batch recipe had after some LinkedIn and YCombinator updtaes.

Summary of changes:

- Rewrote some of the broken prompts
- Swapped the scrapeContent API to pageQuery to retrieve the list of employees
- Added some wait time between operations because windows were not being loaded completely